### PR TITLE
Update README.md about type hierarchy of metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 	d(x, z) <= d(x, y) + d(y, z)  for all x, y, z
 
-This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of *semi-metrics*. In practice this also means that the type definitions for `SemiMetric` and `Metric` do not include positive definiteness, x != y does not imply that d(x, y) = 0 in general.
+This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only
+perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of
+*semi-metrics*. This is why the type definitions for `SemiMetric` and `Metric` do not include positive definiteness, `x != y` does not imply
+that `d(x, y) != 0` in general, as this does not change computations.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 	d(x, z) <= d(x, y) + d(y, z)  for all x, y, z
 
-This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of *semi-metrics*.
+This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only
+perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of
+*semi-metrics*. This is why the type definitions for `SemiMetric` and `Metric` do not include positive definiteness, `x != y` does not imply
+that `d(x, y) != 0` in general, as this does not change computations.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ At the top of this hierarchy is an abstract class **PreMetric**, which is define
 
 	d(x, z) <= d(x, y) + d(y, z)  for all x, y, z
 
-This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of *semi-metrics*.
+This type system has practical significance. For example, when computing pairwise distances between a set of vectors, you may only perform computation for half of the pairs, and derive the values immediately for the remaining halve by leveraging the symmetry of *semi-metrics*. In practice this also means that the type definitions for `SemiMetric` and `Metric` do not include positive definiteness, x != y does not imply that d(x, y) = 0 in general.
 
 Each distance corresponds to a distance type. The type name and the corresponding mathematical definitions of the distances are listed in the following table.
 


### PR DESCRIPTION
Add a sentence on how the types `SemiMetric` and `Metric` does not include positive definiteness as in the mathematical definition. It is possible for an object of these types to have  x != y and d(x, y) = 0.

This was created in response to #153.